### PR TITLE
Add .8 and .9 to file extensions

### DIFF
--- a/Man Page/Man Page.sublime-syntax
+++ b/Man Page/Man Page.sublime-syntax
@@ -6,7 +6,7 @@
 ---
 name: Man Page (groff/troff)
 scope: text.groff
-file_extensions: [man, groff, troff, '1', '2', '3', '4', '5', '6', '7']
+file_extensions: [man, groff, troff, '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
 contexts:
   main:


### PR DESCRIPTION
Debian/Ubuntu list the respective sections in their man(1) as:
  8 System administration commands (usually only for root)
  9 Kernel routines [Non standard]

https://manpages.debian.org/buster/man-db/man.1.en.html#DESCRIPTION